### PR TITLE
Edu resources

### DIFF
--- a/app/translations/en_us.coffee
+++ b/app/translations/en_us.coffee
@@ -785,15 +785,20 @@ module.exports =
           <li><a href='https://www.youtube.com/watch?v=iRhdDs91aas'> TropicMind.com: Ecosystem and Food Chain (aimed for younger children)</a> </li>
         </ul>
 
-        <p>Please visit Lincoln Park Zoo's Educator's Resources <a href="http://www.lpzoo.org/education/educators-resources"> webpage</a> to access curriculum guides, Zoo field trip and self-tour information, accessibility  kits, and links to several multi-media apps.
-        </p>
-
-        <p>The Adler Planetarium is dedicated to helping the public experience science and discover the universe through field trips, school partnerships, child and teen programming. See the Teach and Learn <a href="http://www.adlerplanetarium.org/educator-resources/">section</a> of the Adler's website for details.
-        </p>
-
         <p>We also recommend checking out the Urban Wildlife Institute <a href="http://www.lpzoo.org/conservation-science/science-centers/urban-wildlife-institute">webpage</a> for more information on the organization.
         </p>
       """
+    partner_resources:
+      nav: "Partner Resouces"
+      header: "Partner resources"  
+      content: """
+          <p>Please visit Lincoln Park Zoo's Educator's Resources <a href="http://www.lpzoo.org/education/educators-resources"> webpage</a> to access curriculum guides, Zoo field trip and self-tour information, accessibility  kits, and links to several multi-media apps.
+          </p>
+
+          <p>The Adler Planetarium is dedicated to helping the public experience science and discover the universe through field trips, school partnerships, child and teen programming. See the Teach and Learn <a href="http://www.adlerplanetarium.org/educator-resources/">section</a> of the Adler's website for details.
+          </p>
+        """
+
     aside:
       content: """
         <h1>Connect with Education</h1>

--- a/app/views/education_page.eco
+++ b/app/views/education_page.eco
@@ -18,6 +18,8 @@
         <%- translate 'p', 'education.overview.p' %>
         <%- translate 'h1', 'education.resources.header' %>
         <%- translate 'div', 'education.resources.content' %>
+        <%- translate 'h1', 'education.partner_resources.header' %>
+        <%- translate 'div', 'education.partner_resources.content' %>
       </div>
     </div>
 


### PR DESCRIPTION
Creates this new sub-heading for Alder and LPZ resources that don't directly pertain to CWW activity.

COPY 
"
Partner resources

Please visit Lincoln Park Zoo's Educator's Resources webpage to access curriculum guides, Zoo field trip and self-tour information, accessibility kits, and links to several multi-media apps.

The Adler Planetarium is dedicated to helping the public experience science and discover the universe through field trips, school partnerships, child and teen programming. See the Teach and Learn section of the Adler's website for details"
